### PR TITLE
Add docstrings and type hints

### DIFF
--- a/play_trained_model.py
+++ b/play_trained_model.py
@@ -1,17 +1,33 @@
 # play_trained_model.py
 import pygame
 import torch
+from typing import Any, Tuple
+
 from game_core import Snake, Apple, Agent
-from ml_model import SnakeNet # Required to instantiate model before loading state_dict
+from ml_model import SnakeNet  # Required to instantiate model before loading state_dict
 from game_constants import (
-    SCREEN_BASE_WIDTH, SCREEN_BASE_HEIGHT, MOVE_INTERVAL_PLAY, LINE_WIDTH,
-    OUTER_RECT_X, OUTER_RECT_Y, OUTER_RECT_WIDTH, OUTER_RECT_HEIGHT,
-    CELL_WIDTH, CELL_HEIGHT, COLS, ROWS, WHITE, BLACK, SNAKE_COLOR, APPLE_COLOR
+    SCREEN_BASE_WIDTH,
+    SCREEN_BASE_HEIGHT,
+    MOVE_INTERVAL_PLAY,
+    LINE_WIDTH,
+    OUTER_RECT_X,
+    OUTER_RECT_Y,
+    OUTER_RECT_WIDTH,
+    OUTER_RECT_HEIGHT,
+    CELL_WIDTH,
+    CELL_HEIGHT,
+    COLS,
+    ROWS,
+    WHITE,
+    BLACK,
+    SNAKE_COLOR,
+    APPLE_COLOR,
 )
 
 MODEL_PATH = "best_snake_model.pt"
 
-def initialize_game_elements_for_play():
+def initialize_game_elements_for_play() -> Tuple[Snake, Apple, Agent, bool]:
+    """Load the trained model and create game objects."""
     game_snake = Snake()
     game_apple = Apple()
     game_apple.respawn(game_snake.body)
@@ -31,7 +47,8 @@ def initialize_game_elements_for_play():
     
     return game_snake, game_apple, ai_agent, False
 
-def draw_game_grid(screen, pygame_instance):
+def draw_game_grid(screen: Any, pygame_instance: Any) -> None:
+    """Draw the outer rectangle and grid lines."""
     pygame_instance.draw.rect(screen, WHITE, (OUTER_RECT_X, OUTER_RECT_Y, OUTER_RECT_WIDTH, OUTER_RECT_HEIGHT), LINE_WIDTH)
     for col_idx in range(1, COLS):
         x_pos = OUTER_RECT_X + col_idx * CELL_WIDTH
@@ -40,16 +57,26 @@ def draw_game_grid(screen, pygame_instance):
         y_pos = OUTER_RECT_Y + row_idx * CELL_HEIGHT
         pygame_instance.draw.line(screen, BLACK, (OUTER_RECT_X + 1, y_pos), (OUTER_RECT_X + OUTER_RECT_WIDTH - 2, y_pos))
 
-def display_score(screen, pygame_instance, score, font):
+def display_score(screen: Any, pygame_instance: Any, score: int, font: Any) -> None:
+    """Render the current score in the top left corner."""
     score_text = font.render(f"Score: {score}", True, WHITE)
     screen.blit(score_text, (OUTER_RECT_X, OUTER_RECT_Y - 40))
 
-def display_centered_message(screen, pygame_instance, text, font, y_offset=0, color=WHITE):
+def display_centered_message(
+    screen: Any,
+    pygame_instance: Any,
+    text: str,
+    font: Any,
+    y_offset: int = 0,
+    color: Tuple[int, int, int] = WHITE,
+) -> None:
+    """Show a message centered on the screen."""
     message_surface = font.render(text, True, color)
     message_rect = message_surface.get_rect(center=(SCREEN_BASE_WIDTH // 2, SCREEN_BASE_HEIGHT // 2 + y_offset))
     screen.blit(message_surface, message_rect)
 
-def main_play_loop():
+def main_play_loop() -> None:
+    """Run a Pygame loop letting the AI play the game."""
     pygame.init()
     screen = pygame.display.set_mode((SCREEN_BASE_WIDTH, SCREEN_BASE_HEIGHT))
     pygame.display.set_caption("Snake Game - AI Playing")

--- a/train.py
+++ b/train.py
@@ -1,13 +1,23 @@
 # train.py
 import random
+from typing import List, Optional, Tuple
+
 import torch
-from game_core import Snake, Apple, Agent # SnakeNet is implicitly part of Agent
+
+from game_core import Snake, Apple, Agent  # SnakeNet is implicitly part of Agent
 from game_constants import COLS, ROWS
 
 class Trainer:
-    def __init__(self, population_size=50, mutation_rate=0.05,
-                 mutation_strength=0.1, mutation_decay=0.97,
-                 min_mutation_strength=0.02):
+    """Genetic algorithm trainer for evolving snake agents."""
+
+    def __init__(
+        self,
+        population_size: int = 50,
+        mutation_rate: float = 0.05,
+        mutation_strength: float = 0.1,
+        mutation_decay: float = 0.97,
+        min_mutation_strength: float = 0.02,
+    ) -> None:
         self.population_size = population_size
         self.mutation_rate = mutation_rate
         self.mutation_strength = mutation_strength
@@ -15,14 +25,16 @@ class Trainer:
         self.mutation_decay = mutation_decay
         self.min_mutation_strength = min_mutation_strength
 
-    def evaluate_population(self):
-        fitness_scores = []
-        for i, agent in enumerate(self.population):
+    def evaluate_population(self) -> List[Tuple[float, Agent]]:
+        """Return fitness scores for the entire population."""
+        fitness_scores: List[Tuple[float, Agent]] = []
+        for agent in self.population:
             fitness = self.run_simulation(agent)
             fitness_scores.append((fitness, agent))
         return fitness_scores
 
-    def run_simulation(self, agent):
+    def run_simulation(self, agent: Agent) -> float:
+        """Simulate one game and return the fitness for ``agent``."""
         sim_snake = Snake()
         sim_apple = Apple()
         sim_apple.respawn(sim_snake.body)
@@ -68,7 +80,8 @@ class Trainer:
         fitness = total_steps_survived + (game_score * 100)
         return fitness
 
-    def evolve_population(self):
+    def evolve_population(self) -> Tuple[float, Optional[Agent]]:
+        """Evolve the agent population by one generation."""
         scored_population = self.evaluate_population()
         scored_population.sort(reverse=True, key=lambda x: x[0])
 
@@ -93,10 +106,11 @@ class Trainer:
             new_population.append(child)
 
         self.population = new_population
-        best_fitness_this_gen = scored_population[0][0] if scored_population else -float('inf')
+        best_fitness_this_gen = scored_population[0][0] if scored_population else -float("inf")
         return best_fitness_this_gen, scored_population[0][1] if scored_population else None
 
-    def mutate_weights(self, weights_tensor):
+    def mutate_weights(self, weights_tensor: torch.Tensor) -> torch.Tensor:
+        """Return a mutated copy of ``weights_tensor``."""
         mutated_weights = weights_tensor.clone()
         for i in range(len(mutated_weights)):
             if random.random() < self.mutation_rate:


### PR DESCRIPTION
## Summary
- document core classes and helper functions
- annotate trainer and agent methods with types
- clarify play loop helpers and add annotations

## Testing
- `python -m py_compile game_core.py train.py play_trained_model.py ml_model.py`

------
https://chatgpt.com/codex/tasks/task_e_683f3a194a94832aa8d53ca81d0b19bf